### PR TITLE
Add deletion additional guard check

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/client/promote/PathsPromoteTrackingRecords.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/client/promote/PathsPromoteTrackingRecords.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.service.tracking.client.promote;
 
+import org.commonjava.indy.service.tracking.model.StoreKey;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -64,24 +66,24 @@ public class PathsPromoteTrackingRecords
     }
 
     public static class PathsPromoteRequest {
-        private String sourceStore;
+        private StoreKey source;
 
-        private String targetStore;
+        private StoreKey target;
 
-        public String getSourceStore() {
-            return sourceStore;
+        public StoreKey getSource() {
+            return source;
         }
 
-        public void setSourceStore(String sourceStore) {
-            this.sourceStore = sourceStore;
+        public void setSource(StoreKey source) {
+            this.source = source;
         }
 
-        public String getTargetStore() {
-            return targetStore;
+        public StoreKey getTarget() {
+            return target;
         }
 
-        public void setTargetStore(String targetStore) {
-            this.targetStore = targetStore;
+        public void setTarget(StoreKey target) {
+            this.target = target;
         }
     }
 }

--- a/src/main/java/org/commonjava/indy/service/tracking/client/promote/PathsPromoteTrackingRecords.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/client/promote/PathsPromoteTrackingRecords.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2022 Red Hat, Inc. (https://github.com/Commonjava/indy-event-model)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.tracking.client.promote;
+
+import java.util.Map;
+import java.util.Set;
+
+public class PathsPromoteTrackingRecords
+{
+    private String trackingId; // user specified tracking id
+
+    private Map<String, PathsPromoteResult> resultMap; // promotion uuid -> result
+
+    public String getTrackingId() {
+        return trackingId;
+    }
+
+    public void setTrackingId(String trackingId) {
+        this.trackingId = trackingId;
+    }
+
+    public Map<String, PathsPromoteResult> getResultMap() {
+        return resultMap;
+    }
+
+    public void setResultMap(Map<String, PathsPromoteResult> resultMap) {
+        this.resultMap = resultMap;
+    }
+
+    public static class PathsPromoteResult {
+
+        private PathsPromoteRequest request;
+
+        private Set<String> completedPaths;
+
+        public PathsPromoteRequest getRequest() {
+            return request;
+        }
+
+        public void setRequest(PathsPromoteRequest request) {
+            this.request = request;
+        }
+
+        public Set<String> getCompletedPaths() {
+            return completedPaths;
+        }
+
+        public void setCompletedPaths(Set<String> completedPaths) {
+            this.completedPaths = completedPaths;
+        }
+    }
+
+    public static class PathsPromoteRequest {
+        private String sourceStore;
+
+        private String targetStore;
+
+        public String getSourceStore() {
+            return sourceStore;
+        }
+
+        public void setSourceStore(String sourceStore) {
+            this.sourceStore = sourceStore;
+        }
+
+        public String getTargetStore() {
+            return targetStore;
+        }
+
+        public void setTargetStore(String targetStore) {
+            this.targetStore = targetStore;
+        }
+    }
+}

--- a/src/main/java/org/commonjava/indy/service/tracking/client/promote/PromoteService.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/client/promote/PromoteService.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc. (https://github.com/Commonjava/indy-tracking-service)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.tracking.client.promote;
+
+import org.commonjava.indy.service.tracking.client.CustomClientRequestFilter;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+@Path( "/api/promotion/admin" )
+@RegisterRestClient( configKey = "promote-service-api" )
+@RegisterProvider( CustomClientRequestFilter.class )
+public interface PromoteService
+{
+    @GET
+    @Path( "/tracking/{trackingId}" )
+    Response getPromoteRecords( final @PathParam( "trackingId" ) String trackingId ) throws Exception;
+}

--- a/src/main/java/org/commonjava/indy/service/tracking/config/IndyTrackingConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/config/IndyTrackingConfiguration.java
@@ -34,4 +34,9 @@ public interface IndyTrackingConfiguration
     @WithName( "track.group.content" )
     @WithDefault( "true" )
     Boolean trackGroupContent();
+
+    @WithName( "deletionAdditionalGuardCheck" )
+    @WithDefault( "false" )
+    Boolean deletionAdditionalGuardCheck();
+
 }

--- a/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
@@ -373,7 +373,7 @@ public class AdminController
      * to find the target store associated with the promotion. If the target store does not match given store,
      * return failed delete validation result.
      */
-    public boolean deletionAdditionalGuardCheck(BatchDeleteRequest deleteRequest )
+    public boolean deletionAdditionalGuardCheck( BatchDeleteRequest deleteRequest )
     {
         if ( !config.deletionAdditionalGuardCheck() )
         {

--- a/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
@@ -26,6 +26,7 @@ import org.commonjava.indy.service.tracking.data.cassandra.CassandraTrackingQuer
 import org.commonjava.indy.service.tracking.exception.ContentException;
 import org.commonjava.indy.service.tracking.exception.IndyWorkflowException;
 import org.commonjava.indy.service.tracking.jaxrs.DTOStreamingOutput;
+import org.commonjava.indy.service.tracking.model.StoreKey;
 import org.commonjava.indy.service.tracking.model.TrackedContent;
 import org.commonjava.indy.service.tracking.model.TrackedContentEntry;
 import org.commonjava.indy.service.tracking.model.TrackingKey;
@@ -381,7 +382,7 @@ public class AdminController
         }
 
         String trackingID = deleteRequest.getTrackingID();
-        final String givenStore = deleteRequest.getStoreKey().toString();
+        final StoreKey givenStore = deleteRequest.getStoreKey();
         final AtomicBoolean isOk = new AtomicBoolean(false);
         try
         {
@@ -396,7 +397,7 @@ public class AdminController
             if ( resultMap != null )
             {
                 resultMap.forEach( (k,v) -> {
-                    if (v.getRequest().getTargetStore().equals(givenStore))
+                    if (v.getRequest().getTarget().equals(givenStore))
                     {
                         isOk.set(true); // set true if any match found
                     }

--- a/src/main/java/org/commonjava/indy/service/tracking/jaxrs/AdminResource.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/jaxrs/AdminResource.java
@@ -357,6 +357,12 @@ public class AdminResource
             return builder.build();
         }
 
+        if ( !controller.deletionAdditionalGuardCheck(request) )
+        {
+            Response.ResponseBuilder builder = Response.status( 400 );
+            return builder.build();
+        }
+
         if ( request.getPaths() == null || request.getPaths().isEmpty() )
         {
             final String baseUrl = uriInfo.getBaseUriBuilder().path( "api" ).build().toString();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ quarkus:
   log:
     level: INFO
     category:
-      "org.commonjava.service.tracking":
+      "org.commonjava.indy.service.tracking":
         level: DEBUG
     console:
       level: DEBUG
@@ -84,7 +84,7 @@ cassandra:
     log:
       level: INFO
       category:
-        "org.commonjava.service.tracking":
+        "org.commonjava.indy.service.tracking":
           level: TRACE
       console:
         enable: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -100,7 +100,6 @@ cassandra:
     track:
       group:
         content: true
-    deletionAdditionalGuardCheck: true
 
   kafka:
     bootstrap:
@@ -122,3 +121,15 @@ cassandra:
           topic: promote-complete
           value:
             deserializer: org.commonjava.indy.service.tracking.handler.PathsPromoteCompleteEventDeserializer
+
+"%test":
+  quarkus:
+    log:
+      level: INFO
+      category:
+        "org.commonjava.indy.service.tracking":
+          level: DEBUG
+      console:
+        enable: true
+  tracking:
+    deletionAdditionalGuardCheck: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,6 +61,8 @@ tracking:
 
 content-service-api/mp-rest/url: http://localhost
 content-service-api/mp-rest/scope: javax.inject.Singleton
+promote-service-api/mp-rest/url: http://localhost
+promote-service-api/mp-rest/scope: javax.inject.Singleton
 
 kafka:
   bootstrap:
@@ -98,6 +100,7 @@ cassandra:
     track:
       group:
         content: true
+    deletionAdditionalGuardCheck: true
 
   kafka:
     bootstrap:

--- a/src/test/java/org/commonjava/indy/service/tracking/handler/MockablePromoteService.java
+++ b/src/test/java/org/commonjava/indy/service/tracking/handler/MockablePromoteService.java
@@ -1,0 +1,53 @@
+package org.commonjava.indy.service.tracking.handler;
+
+import io.quarkus.test.Mock;
+import org.commonjava.indy.service.tracking.client.promote.PathsPromoteTrackingRecords;
+import org.commonjava.indy.service.tracking.client.promote.PromoteService;
+import org.commonjava.indy.service.tracking.jaxrs.DTOStreamingOutput;
+import org.commonjava.indy.service.tracking.jaxrs.ResponseHelper;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Mock
+@RestClient
+public class MockablePromoteService
+                implements PromoteService
+{
+    @Inject
+    ResponseHelper helper;
+    @Override
+    public Response getPromoteRecords(String trackingId) throws Exception
+    {
+/*
+        PathsPromoteTrackingRecords records = new PathsPromoteTrackingRecords();
+        records.setTrackingId(trackingId);
+        Map<String, PathsPromoteTrackingRecords.PathsPromoteResult> resultMap = new HashMap<>();
+        PathsPromoteTrackingRecords.PathsPromoteResult result = new PathsPromoteTrackingRecords.PathsPromoteResult();
+        PathsPromoteTrackingRecords.PathsPromoteRequest request = new PathsPromoteTrackingRecords.PathsPromoteRequest();
+        request.setSourceStore("maven:remote:src");
+        request.setTargetStore("maven:remote:test");
+        result.setRequest(request);
+        Set<String> completedPaths = new HashSet<>();
+        completedPaths.add("a/b/c");
+        result.setCompletedPaths(completedPaths);
+        resultMap.put("uuid-1", result);
+        records.setResultMap(resultMap);
+        return helper.formatOkResponseWithJsonEntity( records );
+*/
+        try (InputStream stream = this.getClass().getClassLoader()
+                .getResourceAsStream( "promote-tracking-records-test.json" ))
+        {
+            Response.ResponseBuilder builder = Response.ok( stream, APPLICATION_JSON );
+            return builder.build();
+        }
+    }
+}

--- a/src/test/java/org/commonjava/indy/service/tracking/jaxrs/AdminResourceTest.java
+++ b/src/test/java/org/commonjava/indy/service/tracking/jaxrs/AdminResourceTest.java
@@ -254,6 +254,7 @@ public class AdminResourceTest
         trackedContentDTO.setUploads( entries );
         trackedContentDTO.setKey( new TrackingKey( TRACKING_ID ) );
 
+        when( adminController.deletionAdditionalGuardCheck( any() ) ).thenReturn( true );
         when( adminController.getRecord( anyString(), anyString() ) ).thenReturn( trackedContentDTO, null );
         given().header( "Content-type", "application/json" )
                .and()
@@ -283,6 +284,7 @@ public class AdminResourceTest
         entries.add( entry );
         trackedContentDTO.setUploads( entries );
         trackedContentDTO.setKey( new TrackingKey( TRACKING_ID ) );
+        when( adminController.deletionAdditionalGuardCheck( any() ) ).thenReturn( true );
         when( adminController.getRecord( anyString(), anyString() ) ).thenReturn( null );
         given().header( "Content-type", "application/json" )
                .and()

--- a/src/test/resources/promote-tracking-records-test.json
+++ b/src/test/resources/promote-tracking-records-test.json
@@ -1,0 +1,32 @@
+{
+  "trackingId" : "build-988945803",
+  "resultMap" : {
+    "e89cc979-de31-4fdb-9bec-78806b7cb845" : {
+      "resultCode" : "DONE",
+      "validations" : {
+        "valid" : true
+      },
+      "request" : {
+        "async" : false,
+        "promotionId" : "e89cc979-de31-4fdb-9bec-78806b7cb845",
+        "trackingId" : "build-988945803",
+        "source" : {
+          "packageType" : "maven",
+          "type" : "hosted",
+          "name" : "source_tracking"
+        },
+        "target" : {
+          "packageType" : "maven",
+          "type" : "remote",
+          "name" : "test"
+        },
+        "paths" : [ "/tracking/test/path1" ],
+        "purgeSource" : false,
+        "dryRun" : false,
+        "fireEvents" : false,
+        "failWhenExists" : false
+      },
+      "completedPaths" : [ "/tracking/test/path1" ]
+    }
+  }
+}


### PR DESCRIPTION
This is for MMENG-3497 FOLO batch deletion additional guard check by promotion tracking record (https://issues.redhat.com/browse/MMENG-3497)

Briefly, when doing batch deletion, it retrieves the promotion record by the trackingID to find the target store associated with the promotion. If the target store does not match given store, return failed delete validation result.

I add a config the dis/enable the check. The default is false.

Unfortunately I failed to run the unit test on my local Fedora due to Cassandra container start up errors. I pushed it here to try CI.