### PR TITLE
Fix the type of the tracked entry

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/change/FoloTrackingListener.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/change/FoloTrackingListener.java
@@ -148,7 +148,7 @@ public class FoloTrackingListener
 
             TrackedContentEntry entry =
                             new TrackedContentEntry( trackingKey, storeKey, accessChannel, event.getSourceLocation(),
-                                                     event.getTargetPath(), DOWNLOAD, event.getSize(), event.getMd5(),
+                                                     event.getTargetPath(), UPLOAD, event.getSize(), event.getMd5(),
                                                      event.getSha1(), event.getChecksum() );
 
             recordManager.recordArtifact( entry );


### PR DESCRIPTION
The fix is trying to fix that even artifacts uploaded from PNC appeared in downloads section. 