### PR TITLE
Add check for filtering the artifacts through proxy

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/change/FoloTrackingListener.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/change/FoloTrackingListener.java
@@ -135,6 +135,13 @@ public class FoloTrackingListener
             return;
         }
         final AccessChannel accessChannel = AccessChannel.valueOf( (String) metadata.get( Constants.ACCESS_CHANNEL ) );
+
+        if ( AccessChannel.GENERIC_PROXY.equals( accessChannel ) )
+        {
+            logger.trace("Skipping tracking of storage for artifacts through proxy.");
+            return;
+        }
+
         String keyString = event.getStoreKey();
         if (StringUtils.isBlank( keyString )) {
             logger.trace( "NOT tracking content without StoreKey" );


### PR DESCRIPTION
The issue is that there are always two records with both `UPLOAD` and `DOWNLOAD` for the artifacts through the proxy. 
Ref: http://pastebin.test.redhat.com/1105798

Previously, we checked the transferoperation to filter this out, but looks we have not defined it in event mode, or is it worth doing that ?  anyway let's fix the issue with this workaround to unblock tests. 