### PR TITLE
Allow batch deletion if promote tracking record not found

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
@@ -389,6 +389,13 @@ public class AdminController
             Response resp = promoteService.getPromoteRecords( trackingID );
             if (!isSuccess(resp))
             {
+                if ( resp.getStatus() == Response.Status.NOT_FOUND.getStatusCode() )
+                {
+                    // Record not exists. It is common because the guide check can not cover old artifacts. Old
+                    // artifacts were promoted without tracking. We just print a log and allow it.
+                    logger.info("Promote tracking record not found but allow deletion, trackingID: {}", trackingID);
+                    return true;
+                }
                 logger.warn( "Deletion guard check failed, status:" + resp.getStatus() );
                 return false;
             }


### PR DESCRIPTION
This is for (https://issues.redhat.com/browse/MMENG-3790) Deletion guard check failed on tracking service. 

Because the promote tracking has not been employed by our user, it always gets 404 during the deletion guide check. Because it is 'additional guide check', I think it is Ok to allow the deletion instead of fail it.