### PR TITLE
Add config for skipDeletionAdditionalGuardCheck pattern

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/config/IndyTrackingConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/config/IndyTrackingConfiguration.java
@@ -39,4 +39,7 @@ public interface IndyTrackingConfiguration
     @WithDefault( "false" )
     Boolean deletionAdditionalGuardCheck();
 
+    @WithName( "skipDeletionAdditionalGuardCheck" )
+    @WithDefault( "^temporary-.*" )
+    String skipDeletionAdditionalGuardCheck();
 }

--- a/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/controller/AdminController.java
@@ -376,9 +376,11 @@ public class AdminController
      */
     public boolean deletionAdditionalGuardCheck( BatchDeleteRequest deleteRequest )
     {
-        if ( !config.deletionAdditionalGuardCheck() )
+        if ( !config.deletionAdditionalGuardCheck() || deleteRequest.getStoreKey().getName()
+                .matches(config.skipDeletionAdditionalGuardCheck()))
         {
-            return true; // as passed if guard check is not enabled
+            logger.debug("Deletion additional check not enabled or skipped, store: {}", deleteRequest.getStoreKey());
+            return true;
         }
 
         String trackingID = deleteRequest.getTrackingID();
@@ -409,7 +411,7 @@ public class AdminController
             logger.warn("Deletion guard check failed", e);
             return false;
         }
-        logger.info("Deletion guard check, trackingID: {}, passed: {}", trackingID, isOk.get());
+        logger.info("Deletion guard check, trackingID: {}, store: {}, passed: {}", trackingID, deleteRequest.getStoreKey(), isOk.get());
         return isOk.get();
     }
 

--- a/src/test/java/org/commonjava/indy/service/tracking/ftests/admin/AdminResourceTest.java
+++ b/src/test/java/org/commonjava/indy/service/tracking/ftests/admin/AdminResourceTest.java
@@ -234,9 +234,22 @@ public class AdminResourceTest
     }
 
     @Test
-    public void testDoDeleteSuccess() throws IndyWorkflowException, JsonProcessingException
+    public void testDoDeleteSuccess() throws Exception
     {
         StoreKey storeKey = new StoreKey( "maven", StoreType.remote, "test" );
+        testDoDeleteInternal( storeKey );
+    }
+
+    @Test
+    public void testDoDeleteSkipGuardCheck() throws Exception
+    {
+        // By default, skip repos with name matching "^temporary-.*"
+        StoreKey storeKey = new StoreKey( "maven", StoreType.remote, "temporary-builds" );
+        testDoDeleteInternal( storeKey );
+    }
+
+    private void testDoDeleteInternal( StoreKey storeKey ) throws Exception
+    {
         BatchDeleteRequest batchDeleteRequest = new BatchDeleteRequest();
         batchDeleteRequest.setStoreKey( storeKey );
         batchDeleteRequest.setTrackingID( TRACKING_ID );


### PR DESCRIPTION
Temporary builds delete the tracking records after it is done. This breaks the guard check. This pr add a pattern to skip the checks for temporary builds.