### PR TITLE
Update Cassandra reconnect policy and default delay value

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraClient.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraClient.java
@@ -18,12 +18,13 @@ package org.commonjava.indy.service.tracking.data.cassandra;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -75,6 +76,8 @@ public class CassandraClient
         socketOptions.setReadTimeoutMillis( config.getReadTimeoutMillis() );
         Cluster.Builder builder = Cluster.builder()
                                          .withoutJMXReporting()
+                                         .withReconnectionPolicy(
+                                                 new ConstantReconnectionPolicy( config.getConstantDelayMs() ) )
                                          .withRetryPolicy( new ConfigurableRetryPolicy( config.getReadRetries(),
                                                                                         config.getWriteRetries() ) )
                                          .addContactPoint( host )

--- a/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraConfiguration.java
@@ -16,10 +16,10 @@
 package org.commonjava.indy.service.tracking.data.cassandra;
 
 import io.quarkus.runtime.Startup;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import java.util.Optional;
 
 import static java.util.Optional.of;
@@ -64,6 +64,10 @@ public class CassandraConfiguration
     @Inject
     @ConfigProperty( name = "cassandra.retries.write", defaultValue = "3" )
     int writeRetries;
+
+    @Inject
+    @ConfigProperty( name = "cassandra.reconnect.delay", defaultValue = "60000" )
+    long constantDelayMs;
 
     @Inject
     @ConfigProperty( name = "cassandra.keyspace" )
@@ -165,6 +169,16 @@ public class CassandraConfiguration
     public void setWriteRetries( int writeRetries )
     {
         this.writeRetries = writeRetries;
+    }
+
+    public long getConstantDelayMs()
+    {
+        return constantDelayMs;
+    }
+
+    public void setConstantDelayMs( long constantDelayMs )
+    {
+        this.constantDelayMs = constantDelayMs;
     }
 
     public String getKeyspace()


### PR DESCRIPTION
Use ConstantReconnectionPolicy instead of exponential policy, see https://issues.redhat.com/browse/MMENG-4231.