### PR TITLE
Reinit Cassandra client and session when session closed

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraTrackingQuery.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/data/cassandra/CassandraTrackingQuery.java
@@ -137,7 +137,7 @@ public class CassandraTrackingQuery
         ResultSet trackingRecord = null;
         try
         {
-            if ( session == null )
+            if ( session == null || session.isClosed() )
             {
                 client.close();
                 client.init();


### PR DESCRIPTION
When scaling down 0 pod for Cassandra, the host 'cassandra-cluster' will also be removed! This is different from testing locally, to prevent the following request IllegalStateException caused by the closed session, also need to refresh the connect session for this case.