### PR TITLE
Add log to batch deletion

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/jaxrs/AdminResource.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/jaxrs/AdminResource.java
@@ -383,6 +383,7 @@ public class AdminResource
     @Produces( APPLICATION_JSON )
     public Response doDelete( @Context final UriInfo uriInfo, final BatchDeleteRequest request )
     {
+        logger.info( "Batch delete request: {}", request );
         String trackingID = request.getTrackingID();
 
         if ( trackingID == null || request.getStoreKey() == null )
@@ -414,6 +415,7 @@ public class AdminResource
                 {
                     paths.add( entry.getPath() );
                 }
+                logger.info( "Set batch delete paths: {}", paths );
                 request.setPaths( paths );
             }
             catch ( IndyWorkflowException e )


### PR DESCRIPTION
Print the batch request details. Helpful to debug sth like:
Ref [MMENG-4359](https://issues.redhat.com/browse/MMENG-4359) Batch delete with read timed out

With this, we can calculate how much time is really taken by subtracting the timestamp of this log from the timeout time.