### PR TITLE
Add action after batch delete to clean up empty parent folders

### DIFF
--- a/src/main/java/org/commonjava/indy/service/tracking/client/storage/StorageBatchDeleteRequest.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/client/storage/StorageBatchDeleteRequest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-tracking-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.tracking.client.storage;
+
+import java.util.Set;
+
+/**
+ * Delete multiple paths in one filesystem.
+ */
+public class StorageBatchDeleteRequest {
+    private Set<String> paths;
+
+    private String filesystem;
+
+    public Set<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(Set<String> paths) {
+        this.paths = paths;
+    }
+
+    public String getFilesystem() {
+        return filesystem;
+    }
+
+    public void setFilesystem(String filesystem) {
+        this.filesystem = filesystem;
+    }
+
+    @Override
+    public String toString() {
+        return "BatchDeleteRequest{" +
+                "paths=" + paths +
+                ", filesystem='" + filesystem + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/commonjava/indy/service/tracking/client/storage/StorageService.java
+++ b/src/main/java/org/commonjava/indy/service/tracking/client/storage/StorageService.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-tracking-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.tracking.client.storage;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.commonjava.indy.service.security.jaxrs.CustomClientRequestFilter;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.Consumes;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/api/storage")
+@RegisterRestClient(configKey = "storage-service-api")
+@RegisterProvider(CustomClientRequestFilter.class)
+public interface StorageService {
+    /**
+     * Delete empty folders by Storage BatchDeleteRequest as JSON body.
+     */
+    @DELETE
+    @Path("/maint/folders/empty")
+    @Consumes(APPLICATION_JSON)
+    Response cleanupEmptyFolders(StorageBatchDeleteRequest request);
+} 

--- a/src/test/java/org/commonjava/indy/service/tracking/handler/MockableStorageService.java
+++ b/src/test/java/org/commonjava/indy/service/tracking/handler/MockableStorageService.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2022-2023 Red Hat, Inc. (https://github.com/Commonjava/indy-tracking-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.service.tracking.handler;
+
+import io.quarkus.test.Mock;
+import jakarta.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
+import org.commonjava.indy.service.tracking.client.storage.StorageBatchDeleteRequest;
+import org.commonjava.indy.service.tracking.client.storage.StorageService;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+@Mock
+@RestClient
+public class MockableStorageService
+                implements StorageService
+{
+    @Override
+    public Response cleanupEmptyFolders( StorageBatchDeleteRequest request )
+    {
+        return Response.status( HttpStatus.SC_OK ).build();
+    }
+}


### PR DESCRIPTION
This is for [MMENG-4386](https://issues.redhat.com/browse/MMENG-4386) Auto-cleanup empty directories after batch delete